### PR TITLE
[Size][KDEV-66606] Add proper version of SnapKit to Package.swift and Podspec

### DIFF
--- a/KustomerChat.podspec
+++ b/KustomerChat.podspec
@@ -17,4 +17,5 @@ Pod::Spec.new do |s|
   s.vendored_frameworks = 'KustomerChat.xcframework'
   s.dependency 'PubNubSwift', '~> 6.3.0'
   s.dependency 'Down', '~> 0.11.0'
+  s.dependency 'SnapKit', '~> 5.0.1'
 end

--- a/Package.resolved
+++ b/Package.resolved
@@ -18,6 +18,15 @@
           "revision": "649a9e93f7744c0961706a7f8781b138707a55ed",
           "version": "6.3.0"
         }
+      },
+      {
+        "package": "SnapKit",
+        "repositoryURL": "https://github.com/SnapKit/SnapKit",
+        "state": {
+          "branch": null,
+          "revision": "d458564516e5676af9c70b4f4b2a9178294f1bc6",
+          "version": "5.0.1"
+        }
       }
     ]
   },

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,8 @@ let package = Package(
   ],
   dependencies: [
     .package(name: "PubNub", url: "https://github.com/pubnub/swift.git", from: "6.3.0"),
-    .package(name: "Down", url: "https://github.com/kustomer/Down", from: "0.11.0")
+    .package(name: "Down", url: "https://github.com/kustomer/Down", from: "0.11.0"),
+    .package(name: "SnapKit", url: "https://github.com/SnapKit/SnapKit", from: "5.0.1")
   ],
   targets: [
     .binaryTarget(


### PR DESCRIPTION
In preparation for https://github.com/kustomer/chat-sdk-ios/pull/1091, SnapKit needs added a dependency in this repo so that `CI for SDK release` will continue to work once https://github.com/kustomer/chat-sdk-ios/pull/1091 is merged