### PR TITLE
[Patch] Bump Reachability

### DIFF
--- a/KustomerChat.podspec
+++ b/KustomerChat.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.dependency 'PubNubSwift', '~> 6.3.0'
   s.dependency 'Down', '~> 0.11.0'
   s.dependency 'SnapKit', '~> 5.0.1'
-  s.dependency 'ReachabilitySwift', '~> 5.0.0'
+  s.dependency 'ReachabilitySwift', '~> 5.2.3'
 end

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/ashleymills/Reachability.swift",
         "state": {
           "branch": null,
-          "revision": "98e968e7b6c1318fb61df23e347bc319761e8acb",
-          "version": "5.0.0"
+          "revision": "7cbd73f46a7dfaeca079e18df7324c6de6d1834a",
+          "version": "5.2.3"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     .package(name: "PubNub", url: "https://github.com/pubnub/swift.git", from: "6.3.0"),
     .package(name: "Down", url: "https://github.com/kustomer/Down", from: "0.11.0"),
     .package(name: "SnapKit", url: "https://github.com/SnapKit/SnapKit", from: "5.0.1")
-    .package(name: "Reachability", url: "https://github.com/ashleymills/Reachability.swift", from: "5.0.0")
+    .package(name: "Reachability", url: "https://github.com/ashleymills/Reachability.swift", from: "5.2.3")
   ],
   targets: [
     .binaryTarget(


### PR DESCRIPTION
Publishing to CocoaPods throws an error, due to version of Reachability having a very low `IOS_DEPLOYMENT__TARGET`
Bumping version to have min iOS 12 support

[Patch]