### PR TITLE
[EUX-1843] Document chat lifecycle hub, matrix, samples, and gateway/API touchpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Embed [Kustomer](https://www.kustomer.com/) in your own products with our chat S
 ----------------
 
 
+## Chat Lifecycle
+
+**CocoaPods / distribution** repo for the **iOS chat SDK** (customer-facing). Runtime chat and **PubNub** behavior are implemented in **chat-sdk-ios**; channel topology is **[chat-api pubnub.md](https://github.com/kustomer/chat-api/blob/master/pubnub.md)**.
+
+**See also:** [chat-api — Chat Lifecycle](https://github.com/kustomer/chat-api/blob/master/README.md#chat-lifecycle) · [chat-sdk-ios](https://github.com/kustomer/chat-sdk-ios)
+
 ## Documentation and guides
 
 [iOS Docs and guides](https://developer.kustomer.com/chat-sdk/v2-iOS/docs)


### PR DESCRIPTION
# User description
[EUX-1843] Chat Lifecycle documentation: CHAT_CONNECTIONS hub updates, cross-platform matrix sample-app links, sample READMEs, and related repo docs. Tracked in Linear.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Describe the new Chat Lifecycle hub entry, linking the CocoaPods distribution info, runtime behavior, and PubNub topology to the relevant repositories for the iOS chat SDK. Highlight the related chat-api documentation sections and the primary CocoaPods and SDK references for easy access.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>raymond.jones@kustomer...</td><td>update readme to inclu...</td><td>October 02, 2024</td></tr>
<tr><td>david@kustomer.com</td><td>update readme</td><td>September 20, 2023</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/kustomer/kustomer-ios/154?tool=ast>(Baz)</a>.